### PR TITLE
Add dependencies on ipaddr, tcpip to META

### DIFF
--- a/lib/META
+++ b/lib/META
@@ -1,7 +1,7 @@
 package "server" (
   version = "0.1"
   description = "Charrua DHCP Server."
-  requires = "cstruct cstruct.syntax sexplib sexplib.syntax cstruct.unix"
+  requires = "cstruct cstruct.syntax sexplib sexplib.syntax cstruct.unix ipaddr tcpip"
   archive(byte) = "dhcp_server.cma"
   archive(byte, plugin) = "dhcp_server.cma"
   archive(native) = "dhcp_server.cmxa"
@@ -12,7 +12,7 @@ package "server" (
 package "wire" (
   version = "0.1"
   description = "Charrua DHCP utilities."
-  requires = "cstruct cstruct.syntax sexplib sexplib.syntax cstruct.unix"
+  requires = "cstruct cstruct.syntax sexplib sexplib.syntax cstruct.unix ipaddr tcpip"
   archive(byte) = "dhcp_wire.cma"
   archive(byte, plugin) = "dhcp_wire.cma"
   archive(native) = "dhcp_wire.cmxa"


### PR DESCRIPTION
Without this I get linking errors when adding charrua-core.{server,wire}
to my binary.