### PR TITLE
Use TCP/IP packet modules to marshal and unmarshal packets.

### DIFF
--- a/_tags
+++ b/_tags
@@ -3,5 +3,5 @@ true: use_menhir
 true: package(cstruct), package(cstruct.ppx)
 true: package(cstruct.unix), package(ipaddr)
 true: package(sexplib), package(ppx_type_conv), package(ppx_sexp_conv)
-true: package(tcpip)
+true: package(tcpip), package(tcpip.udp), package(tcpip.ipv4), package(tcpip.ethif)
 <test/*.native>: package(io-page.unix)

--- a/lib/dhcp_wire.mli
+++ b/lib/dhcp_wire.mli
@@ -752,7 +752,7 @@ type pkt = {
 
 (** Conversions for {! pkt}. *)
 
-val pkt_of_buf : Cstruct.t -> int -> [> `Error of string | `Ok of pkt ]
+val pkt_of_buf : Cstruct.t -> int -> (pkt, string) Result.result
 val buf_of_pkt : pkt -> Cstruct.t
 
 val pkt_of_sexp : Sexplib.Sexp.t -> pkt

--- a/opam
+++ b/opam
@@ -21,4 +21,6 @@ depends: [
   "menhir"
   "ipaddr"
   "tcpip"
+  "result"
+  "rresult"
 ]

--- a/test/pcap.ml
+++ b/test/pcap.ml
@@ -44,14 +44,14 @@ let num_packets = ref 0
 
 let test_packet p len =
   match (Dhcp_wire.pkt_of_buf p len) with
-  | `Error e -> failwith e
-  | `Ok pkt ->
+  | Result.Error e -> failwith e
+  | Result.Ok pkt ->
     if verbose then
       printf "DHCP: %s\n%!" (Dhcp_wire.pkt_to_string pkt);
     let buf = Dhcp_wire.buf_of_pkt pkt in
     match (Dhcp_wire.pkt_of_buf buf len) with
-    | `Error e -> failwith e
-    | `Ok pkt2 ->
+    | Result.Error e -> failwith e
+    | Result.Ok pkt2 ->
       if pkt2 <> pkt then begin
         printf "buffers differ !\n";
         printf "pcap buf:";


### PR DESCRIPTION
Build against current mirage-tcpip trunk.

@haesbaert , please let me know what you think of this PR - I had hoped that the new interface would make applications like the Charrua DHCP server easier to write and deal with.  The changed code certainly is shorter, and seems to replicate less of the serialization and deserialization logic.