### PR TITLE
Set the lease time to the default for fixed addresses

### DIFF
--- a/lib/dhcp_server.ml
+++ b/lib/dhcp_server.ml
@@ -218,9 +218,8 @@ module Lease = struct
     let tm_end = Int32.add tm_start duration in
     { tm_start; tm_end; addr; client_id }
 
-  (* XXX defaults fixed leases to one hour, policy does not belong here. *)
-  let make_fixed mac addr ~now =
-    make (Dhcp_wire.Hwaddr mac) addr ~duration:(Int32.of_int (60 * 60)) ~now
+  let make_fixed mac addr ~duration ~now =
+    make (Dhcp_wire.Hwaddr mac) addr ~duration ~now
 
   let timeleft lease ~now =
     let left = (Int32.to_float lease.tm_end) -. now in
@@ -356,7 +355,7 @@ module Input = struct
 
   let find_lease config client_id mac db ~now =
     match (fixed_addr_of_mac config mac) with
-    | Some fixed_addr -> Some (Lease.make_fixed mac fixed_addr ~now), true
+    | Some fixed_addr -> Some (Lease.make_fixed mac fixed_addr ~duration:config.default_lease_time ~now), true
     | None -> Lease.lease_of_client_id client_id db, false
 
   let good_address config mac addr db =

--- a/lib/dhcp_server.mli
+++ b/lib/dhcp_server.mli
@@ -84,7 +84,7 @@ module Lease : sig
   val sexp_of_t : t -> Sexplib.Sexp.t
   val t_of_sexp : Sexplib.Sexp.t -> t
 
-  val make_fixed : Macaddr.t -> Ipaddr.V4.t -> now:float -> t
+  val make_fixed : Macaddr.t -> Ipaddr.V4.t -> duration:int32 -> now:float -> t
   val timeleft : t -> now:float -> int32
   val timeleft_exn : t -> now:float -> int32
   val timeleft3 : t -> float -> float -> now:float -> int32 * int32 * int32


### PR DESCRIPTION
We're currently using a fixed address mapping in the docker/vpnkit project and it's working well. We'd like to be able to quickly refresh some of the DHCP settings such as

- search domains
- network time servers

To make this work we need to set a short lease time for fixed mappings and update the server configuration, however currently there's a hardcoded 1 hour lease time for fixed mappings. This patch replaces this 1 hour with the default lease time from the server configuration -- what do you think?
