### PR TITLE
add rresult & tcpip library dependencies to _tags

### DIFF
--- a/lib/META
+++ b/lib/META
@@ -1,7 +1,9 @@
+requires = "cstruct cstruct.ppx sexplib ipaddr result rresult"
+
 package "server" (
   version = "0.1"
   description = "Charrua DHCP Server."
-  requires = "io-page.unix cstruct cstruct.ppx sexplib cstruct.unix ipaddr tcpip"
+  requires = "io-page.unix cstruct.unix tcpip tcpip.ethif tcpip.ipv4 tcpip.udp"
   archive(byte) = "dhcp_server.cma"
   archive(byte, plugin) = "dhcp_server.cma"
   archive(native) = "dhcp_server.cmxa"
@@ -12,7 +14,7 @@ package "server" (
 package "wire" (
   version = "0.1"
   description = "Charrua DHCP utilities."
-  requires = "io-page.unix cstruct cstruct.ppx sexplib cstruct.unix ipaddr tcpip"
+  requires = "io-page.unix cstruct.unix tcpip tcpip.ethif tcpip.ipv4 tcpip.udp"
   archive(byte) = "dhcp_wire.cma"
   archive(byte, plugin) = "dhcp_wire.cma"
   archive(native) = "dhcp_wire.cmxa"


### PR DESCRIPTION
Without these additions, applications attempting to use charrua-core's libraries can't build binaries easily:

```
$ ./build.sh 
Finished, 0 targets (0 cached) in 00:00:00.
+ ocamlfind ocamlopt -linkpkg -g -package rawlink -package cmdliner -package ipaddr -package tuntap -package cstruct -package cstruct.lwt -package cstruct.unix -package lwt.unix -package charrua-core.server src/charruad.cmx -o src/charruad.native
File "_none_", line 1:
Error: No implementations provided for the following modules:
         Rresult referenced from /home/user/.opam/dhcharrua-client/lib/charrua-core/dhcp_server.cmxa(Dhcp_wire)
         Ipv4_packet referenced from /home/user/.opam/dhcharrua-client/lib/charrua-core/dhcp_server.cmxa(Dhcp_wire)
         Ethif_packet referenced from /home/user/.opam/dhcharrua-client/lib/charrua-core/dhcp_server.cmxa(Dhcp_wire)
         Ipv4_wire referenced from /home/user/.opam/dhcharrua-client/lib/charrua-core/dhcp_server.cmxa(Dhcp_wire)
         Udp_packet referenced from /home/user/.opam/dhcharrua-client/lib/charrua-core/dhcp_server.cmxa(Dhcp_wire)
         Ethif_wire referenced from /home/user/.opam/dhcharrua-client/lib/charrua-core/dhcp_server.cmxa(Dhcp_wire)
         Udp_wire referenced from /home/user/.opam/dhcharrua-client/lib/charrua-core/dhcp_server.cmxa(Dhcp_wire)
Command exited with code 2.
Compilation unsuccessful after building 4 targets (0 cached) in 00:00:00.
```