### PR TITLE
dhcp-server: stop the lease scan at the pool top, not an absolute address

### DIFF
--- a/server/dhcp_server.ml
+++ b/server/dhcp_server.ml
@@ -374,7 +374,7 @@ module Lease = struct
       let ip = Ipaddr.V4.of_int32 (Int32.add low_32 off) in
       if addr_free ip db then
         Some ip
-      else if off = high_32 then
+      else if ip = high_ip then
         None
       else
         linear_loop (Int32.succ off)


### PR DESCRIPTION
`linear_loop` compared the pool offset `off` to the absolute `high_32`, so on a pool that does not start at 0 it could hand out an address outside the configured range. Compare the computed address instead: `ip = high_ip`.