### PR TITLE
dhcp-client: use DHCPOFFER server-id if available

### DIFF
--- a/client/dhcp_client.ml
+++ b/client/dhcp_client.ml
@@ -126,14 +126,19 @@ let make_request ?(ciaddr = Ipaddr.V4.any) ~xid ~chaddr ~srcmac ~siaddr ~options
   })
 
 (* respond to an incoming DHCPOFFER. *)
-let offer (t : t) ~xid ~chaddr ~server_ip ~request_ip ~offer_options:_ =
+let offer (t : t) ~xid ~chaddr ~server_ip ~request_ip ~offer_options =
   let open Dhcp_wire in
   (* TODO: make sure the offer contains everything we expect before we accept it *)
   let options = [
     Message_type DHCPREQUEST;
     Request_ip request_ip;
-    Server_identifier server_ip;
   ] @ t.options
+  in
+  let options =
+    match Dhcp_wire.find_server_identifier offer_options with
+    | None -> options
+    | Some server_ip ->
+      Server_identifier server_ip :: options
   in
   let options =
     match t.request_options with
@@ -199,14 +204,7 @@ let input t buf =
     | Some DHCPOFFER, Selecting dhcpdiscover ->
         (* "the mechanism used to select one DHCPOFFER [is] implementation
            dependent" (RFC2131) so just take the first one *)
-        let server_ip =
-          (* Some servers put 0.0.0.0 as siaddr (which I find dubious), but put
-             a valid IP as server identifier option. *)
-          Option.value
-            (Dhcp_wire.find_server_identifier incoming.options)
-            ~default:incoming.siaddr
-        in
-        let dhcprequest = offer t ~server_ip
+        let dhcprequest = offer t ~server_ip:incoming.siaddr
                           ~request_ip:incoming.yiaddr
                           ~offer_options:incoming.options
                           ~xid:dhcpdiscover.xid

--- a/client/dhcp_client.ml
+++ b/client/dhcp_client.ml
@@ -199,7 +199,12 @@ let input t buf =
     | Some DHCPOFFER, Selecting dhcpdiscover ->
         (* "the mechanism used to select one DHCPOFFER [is] implementation
            dependent" (RFC2131) so just take the first one *)
-        let dhcprequest = offer t ~server_ip:incoming.siaddr
+        let server_ip =
+          Option.value
+            (Dhcp_wire.find_server_identifier incoming.options)
+            ~default:incoming.siaddr
+        in
+        let dhcprequest = offer t ~server_ip
                           ~request_ip:incoming.yiaddr
                           ~offer_options:incoming.options
                           ~xid:dhcpdiscover.xid

--- a/client/dhcp_client.ml
+++ b/client/dhcp_client.ml
@@ -200,6 +200,8 @@ let input t buf =
         (* "the mechanism used to select one DHCPOFFER [is] implementation
            dependent" (RFC2131) so just take the first one *)
         let server_ip =
+          (* Some servers put 0.0.0.0 as siaddr (which I find dubious), but put
+             a valid IP as server identifier option. *)
           Option.value
             (Dhcp_wire.find_server_identifier incoming.options)
             ~default:incoming.siaddr


### PR DESCRIPTION
My router's DHCP server sends a DHCPOFFER whose `siaddr` is `0.0.0.0` (which I find very dubious) but has a server identifier (option 54) with the correct ip address. Without this patch my client sends a `DHCPREQUEST` with server identifier `0.0.0.0` which the DHCP server (understandably) ignores.

Reading the RFC for server identifier I think this implementation makes sense https://datatracker.ietf.org/doc/html/rfc2132#section-9.7

Now, if the DHCP server doesn't send server identifier (option 54) I'm not sure we should synthesize it as we do...